### PR TITLE
Replace aws-sdk dependency with aws-sdk-v1

### DIFF
--- a/s3_multipart_upload.gemspec
+++ b/s3_multipart_upload.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.files         = Dir["config/**/*", "lib/**/*.rb", "app/**/*", "LICENSE.txt", "README.md"]
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "aws-sdk", "< 2.0"
+  spec.add_dependency "aws-sdk-v1"
   spec.add_dependency "google-api-client"
   spec.add_dependency "railties"
   spec.add_dependency "coffee-script"


### PR DESCRIPTION
This update allows users to install version 1 and version 2 in the same application.

See the following for more info:

http://ruby.awsblog.com/post/TxFKSK2QJE6RPZ/Upcoming-Stable-Release-of-AWS-SDK-for-Ruby-Version-2
