### PR TITLE
Force google api to version 0.8.7

### DIFF
--- a/s3_multipart_upload.gemspec
+++ b/s3_multipart_upload.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "aws-sdk-v1"
-  spec.add_dependency "google-api-client"
+  spec.add_dependency "google-api-client", "~> 0.8.6"
   spec.add_dependency "railties"
   spec.add_dependency "coffee-script"
 


### PR DESCRIPTION
The latest version (0.9.13) of the [google api client](https://github.com/google/google-api-ruby-client) has breaking changes. This update coalesces the gem to last version before the dissolution of use occurs. 
